### PR TITLE
Update `textsize()` method to `textbbox()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Instructions
 
 - `pip install qrcode[pil]`
+- If using a Debian-based Linux operating systems: `sudo apt install ttf-mscorefonts-installer`
 - Execute `python generator.py`
 - Follow instructions

--- a/generator.py
+++ b/generator.py
@@ -158,11 +158,11 @@ if __name__ == "__main__":
                     font = ImageFont.truetype("Arial.ttf", 30)
 
                     # Calculate text size and position
-                    text_size = draw.textsize(c, font)
-                    if text_size[0] > img.size[0]:
+                    _, _, text_width, text_height = draw.textbbox((0, 0), c, font=font)
+                    if text_width > img.size[0]:
                         font = ImageFont.truetype("Arial.ttf", 15)
-                        text_size = draw.textsize(c, font)
-                    text_position = ((img.size[0] - text_size[0]) // 2, img.size[1] - text_size[1] - 10)
+                        _, _, text_width, text_height = draw.textbbox((0, 0), c, font=font)
+                    text_position = ((img.size[0] - text_width) // 2, img.size[1] - text_height - 10)
 
                     # Draw text on the image
                     draw.text(text_position, c, font=font, fill="black")


### PR DESCRIPTION
## Changes
- In `README`, add explanation about how to install `Arial` font in Linux systems.
- In `generator.py`, update `textsize()` method to `textbbox()` method as it was deprecated in `PIL version 9.2.0`

### References
- [Font size and offset methods](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods)
- [One StackOverflow solution](https://stackoverflow.com/a/76948812)